### PR TITLE
Added support for WebHooks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'bugsnag'
 gem 'typhoeus'
 gem 'capybara'
 gem 'poltergeist'
+gem 'oj'
 
 gem 'slack-notifier'
 # gem 'hookly', '~> 0.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,6 +252,3 @@ DEPENDENCIES
   typhoeus
   uglifier
   webmock
-
-BUNDLED WITH
-   1.10.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
     multi_json (1.11.1)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    oj (2.12.10)
     origin (2.1.1)
     poltergeist (1.6.0)
       capybara (~> 2.1)
@@ -237,6 +238,7 @@ DEPENDENCIES
   mock_redis
   mongo!
   mongoid!
+  oj
   poltergeist
   puma
   rails (~> 4.2)

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -9,3 +9,10 @@
     color: #333333;
   }
 }
+
+.checkbox {
+  label {
+    padding-left: 27px;
+    font-weight: bold;
+  }
+}

--- a/app/controllers/application.rb
+++ b/app/controllers/application.rb
@@ -37,6 +37,14 @@ class Application < ActionController::Base
     else
       redirect_to url_for(:controller => @model.class.name.underscore.pluralize, :action => 'show', :id => @model.id)
     end
-
   end
+
+  #converts checkboxes in params to boolean values
+  def parse_checkboxes(params, *keys)
+    keys.each do |v|
+      params[v.to_sym] = params.key?(v.to_sym) && !params[v.to_sym].empty? ? true : false
+    end
+    params
+  end
+
 end

--- a/app/controllers/hooks.rb
+++ b/app/controllers/hooks.rb
@@ -1,0 +1,35 @@
+class Hooks < Application
+  before_action :load_test, :only => [:new, :create]
+  before_action :load_model, :only => [:edit, :update]
+
+  def new
+  end
+
+  def create
+    @hook = @model.hooks.new
+
+    update
+  end
+
+  def edit
+  end
+
+  def update
+    parsed_params = parse_checkboxes params.permit(*Hook.allows), :include_response, :enabled
+    @hook.update(parsed_params)
+
+    respond @hook
+  end
+
+  private
+
+  def load_test
+    @model = user.tests.find(params[:test_id])
+  end
+
+  def load_model
+    @hook = Hook.find(params[:id])
+    @model = user.tests.find(@hook.test_id) # security
+  end
+
+end

--- a/app/lib/web_hook.rb
+++ b/app/lib/web_hook.rb
@@ -1,0 +1,29 @@
+class WebHook
+  def self.run(hook, test_run)
+    data = test_run.as_json
+
+    unless hook.include_response
+      data.delete(:headers)
+      data.delete(:body)
+    end
+
+    data[:test] = test_run.test.as_json.select{|k,v| [:id, :name, :url].include? k}
+    if test_run.failed_check_id
+      data[:success] = false
+      data[:failed_check] = test_run.failed_check.as_json
+    else
+      data[:success] = true
+      data[:failed_check] = nil
+    end
+
+    request = Typhoeus::Request.new(hook.url,
+      :method => :post,
+      :headers => {"Content-Type" => "application/json"},
+      :body => Oj.dump(data, mode: :compat, time_format: :xmlschema)
+    )
+
+    Response.from_api(request.run)
+  end
+
+
+end

--- a/app/models/hook.rb
+++ b/app/models/hook.rb
@@ -1,0 +1,17 @@
+class Hook < Model
+  attrs String => {:name => :n, :url => :u },
+    Mongoid::Boolean => { :include_response => :ir, :enabled => :e  }
+
+  allow :name, :url, :include_response, :enabled
+
+  validates :test_id, :url, :name, :presence => true
+
+  belongs_to :test
+
+  private
+
+  def defaults_before_create
+    self.include_response = false unless self.include_response
+    self.enabled = false unless self.enabled
+  end
+end

--- a/app/models/test.rb
+++ b/app/models/test.rb
@@ -13,7 +13,7 @@ class Test < Model
   validates :user_id, :url, :presence => true
 
   belongs_to :user
-  has_many :checks, :test_runs
+  has_many :checks, :hooks, :test_runs
 
   private
 

--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -6,6 +6,8 @@ class TestRun < Model
 
   validates :user_id, :test_id, :presence => true
 
+  allow :code, :run_at, :duration, :failed_check_id, :headers, :body
+
   belongs_to :user, :test
   belongs_to :failed_check, :class_name => 'Check'
 

--- a/app/views/hooks/edit.html.erb
+++ b/app/views/hooks/edit.html.erb
@@ -1,0 +1,2 @@
+<%= render :partial => 'shared/top' %>
+<%= render :partial => 'shared/edit/hook', :locals => { :hook => @hook } %>

--- a/app/views/hooks/new.html.erb
+++ b/app/views/hooks/new.html.erb
@@ -1,0 +1,2 @@
+<%= render :partial => 'shared/top' %>
+<%= render :partial => 'shared/edit/hook', :locals => { :hook => @model.hooks.new } %>

--- a/app/views/shared/edit/_hook.html.erb
+++ b/app/views/shared/edit/_hook.html.erb
@@ -1,5 +1,4 @@
-<div class="col-md-3"></div>
-<div class="panel panel-default col-md-6">
+<div class="panel panel-default col-md-6 col-md-offset-3">
   <% action = hook.persisted? ? url_for(:controller => 'hooks', :action => 'update', :id => @hook.id) : url_for(:controller => 'hooks', :action => 'create') %>
   <form class="form-horizontal" method="post" action="<%= action %>">
     <fieldset>

--- a/app/views/shared/edit/_hook.html.erb
+++ b/app/views/shared/edit/_hook.html.erb
@@ -1,0 +1,46 @@
+<div class="col-md-3"></div>
+<div class="panel panel-default col-md-6">
+  <% action = hook.persisted? ? url_for(:controller => 'hooks', :action => 'update', :id => @hook.id) : url_for(:controller => 'hooks', :action => 'create') %>
+  <form class="form-horizontal" method="post" action="<%= action %>">
+    <fieldset>
+      <legend><%= hook.persisted? ? 'Update' : 'Create' %> WebHook</legend>
+
+      <div class="form-group">
+        <label class="col-md-3 control-label" for="hook-name">Name</label>
+        <div class="col-md-9">
+          <input id="hook-name" name="name" type="text" value="<%= hook.name %>" placeholder="Name to describe this WebHook" class="form-control input-md" required="">
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label class="col-md-3 control-label" for="hook-url">URL</label>
+        <div class="col-md-9">
+          <input id="hook-url" name="url" type="text" value="<%= hook.url %>" placeholder="URL of WebHook" class="form-control input-md" required="">
+        </div>
+      </div>
+
+      <div class="checkbox">
+        <label class="col-md-9 col-md-offset-3">
+          <input name="include_response" type="checkbox"<%= hook.include_response ? ' checked=""' : '' %>> Include Full Response Data (header / body)
+        </label>
+      </div>
+
+      <div class="checkbox">
+        <label class="col-md-9 col-md-offset-3">
+          <input name="enabled" type="checkbox"<%= hook.enabled ? ' checked=""' : '' %>> Enabled
+        </label>
+      </div>
+
+      <input type="hidden" name="_method" value="<%= hook.persisted? ? 'patch' : 'post' %>">
+      <%= csrf_form_tags %>
+
+      <div class="form-group pull-right">
+        <label class="control-label" for="save"></label>
+        <div class="col-md-1">
+          <button id="save" name="save" class="btn btn-primary"><%= hook.persisted? ? 'Save' : 'Create' %></button>
+        </div>
+      </div>
+    </fieldset>
+  </form>
+</div>
+

--- a/app/views/shared/list/_test.html.erb
+++ b/app/views/shared/list/_test.html.erb
@@ -52,18 +52,41 @@
       </div>
     <% end %>
   </div>
-  <% checks = test.checks.to_a %>
-  <a class="btn test-toggle test-checks-toggle" data-toggle="collapse" data-target="#test-<%= test.id %> .test-checks">Checks (<%= checks.size %>) <span class="caret"></span></a>
-  <a class="btn test-toggle test-checks-new" href="<%= new_test_check_path(test) %>"><span class="glyphicon glyphicon-plus"></span><span>Add a Check</span></a>
 
-  <div class="test-checks collapse in">
-    <ul class="test-check-items list-group">
-      <% checks.each do |check| %>
-        <li id="check-<%= check.id %>" class="list-group-item">
-          <span><%= check.decorator.new(check) %></span>
-          <span class="pull-right check-edit"><a href="<%= edit_check_path(check) %>">Edit</a></span>
-        </li>
-      <% end %>
-    </ul>
+  <div class="test-checks-list">
+    <% checks = test.checks.to_a %>
+    <a class="btn test-toggle test-checks-toggle" data-toggle="collapse" data-target="#test-<%= test.id %> .test-checks">Checks (<%= checks.size %>) <span class="caret"></span></a>
+    <a class="btn test-toggle test-checks-new" href="<%= new_test_check_path(test) %>"><span class="glyphicon glyphicon-plus"></span><span>Add a Check</span></a>
+
+    <div class="test-checks collapse in">
+      <ul class="test-check-items list-group">
+        <% checks.each do |check| %>
+          <li id="check-<%= check.id %>" class="list-group-item">
+            <span><%= check.decorator.new(check) %></span>
+            <span class="pull-right check-edit"><a href="<%= edit_check_path(check) %>">Edit</a></span>
+          </li>
+        <% end %>
+      </ul>
+    </div>
   </div>
+
+  <div class="test-hooks-list">
+    <% hooks = test.hooks.to_a %>
+    <a class="btn test-toggle test-hooks-toggle" data-toggle="collapse" data-target="#test-<%= test.id %> .test-hooks">WebHooks (<%= hooks.size %>) <span class="caret"></span></a>
+    <a class="btn test-toggle test-hooks-new" href="<%= new_test_hook_path(test) %>"><span class="glyphicon glyphicon-plus"></span><span>Add a WebHook</span></a>
+
+    <div class="test-hooks collapse">
+      <ul class="test-hook-items list-group">
+        <% hooks.each do |hook| %>
+          <li id="hook-<%= hook.id %>" class="list-group-item">
+            <span><%= hook.name %></span>
+            <span class="label label-<%= hook.enabled ? 'success' : 'danger' %>"><%= hook.enabled ? 'Enabled' : 'Disabled' %></span>
+            <span class="pull-right hook-edit"><a href="<%= edit_hook_path(hook) %>">Edit</a></span>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+
+
 </li>

--- a/app/workers/test_run_worker.rb
+++ b/app/workers/test_run_worker.rb
@@ -22,5 +22,10 @@ class TestRunWorker < Worker
     elsif last_failed
       Notify.completed(:passed, test_run)
     end
+
+    test.hooks.where(enabled:true).each do |hook|
+      WebHook.run(hook,test_run)
+    end
+
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,11 @@ Rails.application.routes.draw do
   resources :sessions, :only => [:create]
   resources :dashboard, :only => [:index]
   resources :checks, :only => [:edit, :update]
+  resources :hooks, :only => [:edit, :update]
 
   resources :tests, :only => [:index, :new, :create, :show, :edit, :update] do
     resources :checks, :only => [:new, :create]
+    resources :hooks, :only => [:new, :create]
     resources :test_runs, :only => [:create]
   end
 

--- a/spec/controllers/hooks_spec.rb
+++ b/spec/controllers/hooks_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+describe Hooks do
+  let(:user) { create(:user) }
+  let(:test) { create(:test, :user => user) }
+  let(:hook) { create(:hook, :test => test) }
+
+  before { sign_in user }
+
+  describe '#new' do
+    let(:response) { get :new, :test_id => test.id }
+
+    it 'should render the hook new' do
+      expect(response).to render_template('hooks/new')
+    end
+  end
+
+  describe '#create' do
+    hook_name = 'Test Hook Name'
+    hook_url = 'http://www.example.com'
+
+    let(:options) { { :url => hook_url, :name => hook_name, :include_response => "on" } }
+    let(:response) { post :create, :test_id => test.id, **options }
+
+    it 'should redirect to the test' do
+      expect(response).to redirect_to(test_path(test))
+    end
+
+    it 'should add the hook' do
+      expect {
+        response
+      }.to change(Hook, :count).by(1)
+
+      hook = Hook.last
+      expect(hook.url).to eq(hook_url)
+      expect(hook.name).to eq(hook_name)
+      expect(hook.include_response).to eq(true)
+    end
+
+    describe '.json' do
+      before { options[:format] = 'json' }
+
+      it 'should return the hook' do
+        json = JSON.parse(response.body)
+
+        hook = Hook.last
+        expect(json['id']).to eq(hook.id.to_s)
+        expect(json['url']).to eq(hook_url)
+        expect(json['name']).to eq(hook_name)
+        expect(json['include_response']).to eq(true)
+      end
+    end
+  end
+
+  describe '#edit' do
+    let(:response) { get :edit, :id => hook.id }
+
+    it 'should render the hook edit' do
+      expect(response).to render_template('hooks/edit')
+    end
+  end
+
+  describe '#update' do
+
+    hook_name = 'Edit Test Hook Name'
+    hook_url = 'http://edit.example.com'
+
+    let(:options) { { :url => hook_url, :name => hook_name, :include_response => "on" } }
+    let(:response) { patch :update, :id => hook.id, **options }
+
+    it 'should redirect to the test' do
+      expect(response).to redirect_to(test_path(test))
+    end
+
+    it 'should update the hook' do
+      response
+
+      hook.reload
+      expect(hook.url).to eq(hook_url)
+      expect(hook.name).to eq(hook_name)
+      expect(hook.include_response).to eq(true)
+    end
+
+    describe '.json' do
+      before { options[:format] = 'json' }
+
+      it 'should return the hook' do
+        json = JSON.parse(response.body)
+
+        expect(json['id']).to eq(hook.id.to_s)
+        expect(json['url']).to eq(hook_url)
+        expect(json['name']).to eq(hook_name)
+        expect(json['include_response']).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/controllers/hooks_spec.rb
+++ b/spec/controllers/hooks_spec.rb
@@ -16,9 +16,8 @@ describe Hooks do
   end
 
   describe '#create' do
-    hook_name = 'Test Hook Name'
-    hook_url = 'http://www.example.com'
-
+    let(:hook_name) {'Test Hook Name'}
+    let(:hook_url) { 'http://www.example.com' }
     let(:options) { { :url => hook_url, :name => hook_name, :include_response => "on" } }
     let(:response) { post :create, :test_id => test.id, **options }
 
@@ -61,10 +60,8 @@ describe Hooks do
   end
 
   describe '#update' do
-
-    hook_name = 'Edit Test Hook Name'
-    hook_url = 'http://edit.example.com'
-
+    let(:hook_name) {'Test Hook Name'}
+    let(:hook_url) { 'http://www.example.com' }
     let(:options) { { :url => hook_url, :name => hook_name, :include_response => "on" } }
     let(:response) { patch :update, :id => hook.id, **options }
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -18,4 +18,11 @@ FactoryGirl.define do
   factory :check do
     association(:test)
   end
+
+  factory :hook do
+    association(:test)
+    url "https://www.example.com/test"
+    name "A Hook Name"
+  end
+
 end

--- a/spec/features/hooks_spec.rb
+++ b/spec/features/hooks_spec.rb
@@ -8,6 +8,8 @@ describe :hooks, :js => true do
   describe '#create' do
     let!(:test) { create(:test, :user => user) }
     let(:hook) { create(:hook, :test => test) }
+    let(:hook_name) {'Test Hook Name'}
+    let(:hook_url) { 'http://www.example.com' }
 
     it 'creates the hook' do
       visit "/tests/#{test.id}/hooks/new"
@@ -15,9 +17,6 @@ describe :hooks, :js => true do
       should_be_on_the(:'hooks/new')
 
       expect(page).to have_content('Create WebHook')
-
-      hook_name = 'Test Hook Name'
-      hook_url = 'http://www.example.com'
 
       fill_in 'name', :with => hook_name
       fill_in 'url', :with => hook_url
@@ -40,6 +39,8 @@ describe :hooks, :js => true do
   describe '#edit' do
     let(:test) { create(:test, :user => user) }
     let(:hook) { create(:hook, :test => test) }
+    let(:hook_name) {'Test Hook Name'}
+    let(:hook_url) { 'http://www.example.com' }
 
     it 'updates the hook' do
       visit "/hooks/#{hook.id}/edit"
@@ -47,9 +48,6 @@ describe :hooks, :js => true do
       should_be_on_the(:edit)
 
       expect(page).to have_content('Update WebHook')
-
-      hook_name = 'Edited Test Hook Name'
-      hook_url = 'http://edit.example.com'
 
       fill_in 'name', :with => hook_name
       fill_in 'url', :with => hook_url

--- a/spec/features/hooks_spec.rb
+++ b/spec/features/hooks_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe :hooks, :js => true do
+  let(:user) { create(:user) }
+
+  before { sign_in user }
+
+  describe '#create' do
+    let!(:test) { create(:test, :user => user) }
+    let(:hook) { create(:hook, :test => test) }
+
+    it 'creates the hook' do
+      visit "/tests/#{test.id}/hooks/new"
+
+      should_be_on_the(:'hooks/new')
+
+      expect(page).to have_content('Create WebHook')
+
+      hook_name = 'Test Hook Name'
+      hook_url = 'http://www.example.com'
+
+      fill_in 'name', :with => hook_name
+      fill_in 'url', :with => hook_url
+      check 'include_response'
+      check 'enabled'
+
+      click_button 'Create'
+
+      expect(current_url).to match(/tests\/#{test.id}$/)
+
+      hook = Hook.last
+      expect(hook.test).to eq(test)
+      expect(hook.name).to eq(hook_name)
+      expect(hook.url).to eq(hook_url)
+      expect(hook.include_response).to eq(true)
+      expect(hook.enabled).to eq(true)
+    end
+  end
+
+  describe '#edit' do
+    let(:test) { create(:test, :user => user) }
+    let(:hook) { create(:hook, :test => test) }
+
+    it 'updates the hook' do
+      visit "/hooks/#{hook.id}/edit"
+
+      should_be_on_the(:edit)
+
+      expect(page).to have_content('Update WebHook')
+
+      hook_name = 'Edited Test Hook Name'
+      hook_url = 'http://edit.example.com'
+
+      fill_in 'name', :with => hook_name
+      fill_in 'url', :with => hook_url
+      check 'include_response'
+      check 'enabled'
+
+      click_button 'Save'
+
+      expect(current_url).to match(/tests\/#{test.id}$/)
+
+      hook.reload
+      expect(hook.name).to eq(hook_name)
+      expect(hook.url).to eq(hook_url)
+      expect(hook.include_response).to eq(true)
+      expect(hook.enabled).to eq(true)
+    end
+  end
+end

--- a/spec/lib/web_hook_spec.rb
+++ b/spec/lib/web_hook_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+describe WebHook do
+  let(:hook_url) {'http://foo.bar/hook'}
+  let(:breed) { 'post' }
+  let(:headers) { '{"Accept":"gzip,deflate","Authorization":"Bearer FGH345","Content-Type":"application/json"}' }
+  let(:test) { create(:test, :breed => breed, :url => 'http://foo.bar/foo', :headers => headers, :json => true, :body => '{"abc":123,"123":"abc"}') }
+  let(:check) { create(:check, :test => test) }
+  let(:hook) { create(:hook, :test => test, :url => hook_url, :enabled => true, :include_response => true) }
+  let(:test_run) { create(:test_run, :code => 200, :duration => 123.12, :test => test, :failed_check => check, :headers=>"test header", :body=>"test body") }
+
+  let!(:request) { double(Typhoeus::Request, :run => response) }
+  let!(:response) { Typhoeus::Response.new }
+
+  let(:run) { described_class.run(hook, test_run) }
+
+  describe '.run' do
+
+    before do
+      allow(Typhoeus::Request).to receive(:new).and_return(request)
+    end
+
+    it 'should make the request' do
+      expect(request).to receive(:run)
+
+      run
+    end
+
+    it 'should request the url' do
+      expect(Typhoeus::Request).to receive(:new).with(hook_url, anything).and_return(request)
+
+      run
+    end
+
+    it 'should send the request body with correct details' do
+      expect(Typhoeus::Request).to receive(:new){ |url,data|
+        expect(data).to include(:body)
+        body = Oj.load(data[:body])
+        expect(body).to include('id','code','run_at','success','duration','failed_check_id','test','headers','body')
+        expect(body['success']).to eq(false)
+      }.and_return(request)
+
+      run
+    end
+
+    describe 'when include_response is false' do
+
+      before do
+        hook.include_response=false
+      end
+
+      it 'should not send the response data' do
+        expect(Typhoeus::Request).to receive(:new){ |url,data|
+          expect(Oj.load(data[:body])).not_to include('headers','body')
+        }.and_return(request)
+
+        run
+      end
+    end
+
+    describe 'when there is no failed_check_id' do
+
+      before do
+        test_run.failed_check_id = nil
+      end
+
+      it 'should set success to true' do
+        expect(Typhoeus::Request).to receive(:new){ |url,data|
+          expect(Oj.load(data[:body])['success']).to eq(true)
+        }.and_return(request)
+
+        run
+      end
+    end
+
+    it 'should return the response' do
+      expect(run.class).to eq(Response)
+      expect(run.raw).to eq(response)
+    end
+
+  end
+end

--- a/spec/models/hook_spec.rb
+++ b/spec/models/hook_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Hook do
+  subject { build(:hook) }
+
+  describe 'validations' do
+    it 'requires a test' do
+      subject.test_id = nil
+      expect(subject).not_to be_valid
+    end
+
+    it 'requires a url' do
+      subject.url = nil
+      expect(subject).not_to be_valid
+    end
+
+    it 'requires a name' do
+      subject.name = nil
+      expect(subject).not_to be_valid
+    end
+  end
+
+  describe '#save' do
+    describe 'on create' do
+      it 'should not include full response data by default' do
+        subject.save
+        expect(subject.include_response).to eq(false)
+      end
+      it 'should be disabled by default' do
+        subject.save
+        expect(subject.enabled).to eq(false)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
- Creating / editing WebHooks is handled the same way as Checks.
- The hooks are sent in the test run worker right after the e-mail notifications.
- There is an option to include the headers/body
- There is an option to disable WebHooks. Disabled hooks are ignored.
- The response from the WebHook is currently discarded.
